### PR TITLE
Adding functional tests that cover this feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ to update UUIDs in your Vagrantfile. If both are specified, the id parameter tak
 * `service_offering_id`- Service offering uuid to use for the instance
 * `service_offering_name`- Service offering name to use for the instance
 * `template_id` - Template uuid to use for the instance
-* `template_name` - Template name to use for the instance
+* `template_name` - Template name to use for the instance, defaults to Vagrants config.vm.box
 * `zone_id` - Zone uuid to launch the instance into
 * `zone_name` - Zone uuid to launch the instance into
 * `keypair` - SSH keypair name

--- a/functional-tests/rsync/Vagrantfile.advanced_networking
+++ b/functional-tests/rsync/Vagrantfile.advanced_networking
@@ -7,7 +7,7 @@ VAGRANTFILE_API_VERSION = '2'
 Vagrant.require_version '>= 1.5.0'
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = 'vagrant-cloudstack-dummy'
+  config.vm.box = ENV['LINUX_TEMPLATE_NAME']
 
   config.vm.provider :cloudstack do |cloudstack, override|
     cloudstack.display_name = ENV['TEST_NAME']
@@ -26,12 +26,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     cloudstack.zone_name             = ENV['ZONE_NAME']
     cloudstack.network_name          = ENV['NETWORK_NAME']
     cloudstack.service_offering_name = ENV['SERVICE_OFFERING_NAME']
-    cloudstack.template_name         = ENV['TEMPLATE_NAME']
 
     cloudstack.network_type          = 'Advanced'
     cloudstack.pf_ip_address         = public_source_nat_ip
     cloudstack.pf_public_port        = public_ssh_port
-    cloudstack.pf_private_port       = '22'
+    cloudstack.pf_private_port       = ENV['PRIVATE_SSH_PORT']
     cloudstack.pf_open_firewall      = open_firewall
 
     unless open_firewall

--- a/functional-tests/run_tests.sh
+++ b/functional-tests/run_tests.sh
@@ -40,11 +40,6 @@ if [ -z "$SERVICE_OFFERING_NAME" ]; then
   exit 1
 fi
 
-if [ -z "$TEMPLATE_NAME" ]; then
-  echo "Template name not set. Quitting"
-  exit 1
-fi
-
 test_dirs=$(find . -type d -mindepth 1 -maxdepth 1 | grep -v ".vagrant")
 
 for test_dir in $test_dirs; do

--- a/functional-tests/vmlifecycle/Vagrantfile.advanced_networking
+++ b/functional-tests/vmlifecycle/Vagrantfile.advanced_networking
@@ -1,0 +1,83 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = '2'
+
+Vagrant.require_version '>= 1.5.0'
+
+machines = {
+  'linux-box' => {
+    'public_port'    => ENV['PUBLIC_SSH_PORT'],
+    'private_port'   => ENV['PRIVATE_SSH_PORT'],
+    'template'       => ENV['LINUX_TEMPLATE_NAME'],
+    'communicator'   => 'ssh',
+    'rsync_disabled' => true
+  },
+  'windows-box' => {
+    'public_port'    => ENV['PUBLIC_WINRM_PORT'],
+    'private_port'   => ENV['PRIVATE_WINRM_PORT'],
+    'template'       => ENV['WINDOWS_TEMPLATE_NAME'],
+    'communicator'   => 'winrm',
+    'rsync_disabled' => true
+  }
+}
+
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |global_config|
+  machines.each_pair do |name, options|
+    global_config.vm.define name do |config|
+      config.vm.box = options['template']
+
+      config.vm.communicator = options['communicator']
+      config.vm.synced_folder ".", "/vagrant", type: "rsync",
+        rsync__exclude: [".git/", "vendor"], disabled: options['rsync_disabled']
+      config.vm.provider :cloudstack do |cloudstack, override|
+
+        cloudstack.display_name = ENV['TEST_NAME']
+
+        cloudstack.host       = ENV['CLOUDSTACK_HOST']
+        cloudstack.path       = '/client/api'
+        cloudstack.port       = '443'
+        cloudstack.scheme     = 'https'
+        cloudstack.api_key    = ENV['CLOUDSTACK_API_KEY']
+        cloudstack.secret_key = ENV['CLOUDSTACK_SECRET_KEY']
+
+        public_source_nat_ip = ENV['PUBLIC_SOURCE_NAT_IP']
+        open_firewall        = ENV['OPEN_FIREWALL'] == "true"
+
+        cloudstack.zone_name             = ENV['ZONE_NAME']
+        cloudstack.network_name          = ENV['NETWORK_NAME']
+        cloudstack.service_offering_name = ENV['SERVICE_OFFERING_NAME']
+
+        cloudstack.network_type          = 'Advanced'
+        cloudstack.pf_ip_address         = public_source_nat_ip
+
+        cloudstack.pf_public_port        = options['public_port']
+        cloudstack.pf_private_port       = options['private_port']
+        cloudstack.pf_open_firewall      = open_firewall
+
+        unless open_firewall
+          cloudstack.firewall_rules = [
+            {
+              ipaddress: public_source_nat_ip,
+              cidrlist:  ENV['SOURCE_CIDR'],
+              protocol:  'tcp',
+              startport: options['public_port'].to_i,
+              endport:   options['public_port'].to_i
+            }
+          ]
+        end
+
+        unless ENV['SSH_KEY'].nil?
+            cloudstack.ssh_key               = ENV['SSH_KEY']
+            cloudstack.ssh_user              = ENV['SSH_USER']
+        end
+
+        unless ENV['WINDOWS_USER'].nil?
+            cloudstack.vm_user = ENV['WINDOWS_USER']
+        end
+      end
+    end
+  end
+end

--- a/functional-tests/vmlifecycle/test.bats
+++ b/functional-tests/vmlifecycle/test.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+
+vagrant_up() {
+  bundle exec vagrant up
+}
+
+vagrant_destroy() {
+  bundle exec vagrant destroy -f
+}
+
+teardown() {
+  run vagrant_destroy
+}
+
+@test "create and destroy vm" {
+  run vagrant_up
+  [ $status = 0 ]
+
+  run vagrant_destroy
+  [ $status = 0 ]
+}
+

--- a/lib/vagrant-cloudstack/action/run_instance.rb
+++ b/lib/vagrant-cloudstack/action/run_instance.rb
@@ -5,6 +5,7 @@ require 'vagrant-cloudstack/util/timer'
 require 'vagrant-cloudstack/model/cloudstack_resource'
 require 'vagrant-cloudstack/service/cloudstack_resource_service'
 
+
 module VagrantPlugins
   module Cloudstack
     module Action
@@ -34,7 +35,7 @@ module VagrantPlugins
           @network          = CloudstackResource.new(domain_config.network_id, domain_config.network_name, 'network')
           @service_offering = CloudstackResource.new(domain_config.service_offering_id, domain_config.service_offering_name, 'service_offering')
           @disk_offering    = CloudstackResource.new(domain_config.disk_offering_id, domain_config.disk_offering_name, 'disk_offering')
-          @template         = CloudstackResource.new(domain_config.template_id, domain_config.template_name, 'template')
+          @template         = CloudstackResource.new(domain_config.template_id, domain_config.template_name || env[:machine].config.vm.box, 'template')
 
           hostname                    = domain_config.name
           network_type                = domain_config.network_type

--- a/lib/vagrant-cloudstack/action/run_instance.rb
+++ b/lib/vagrant-cloudstack/action/run_instance.rb
@@ -5,7 +5,6 @@ require 'vagrant-cloudstack/util/timer'
 require 'vagrant-cloudstack/model/cloudstack_resource'
 require 'vagrant-cloudstack/service/cloudstack_resource_service'
 
-
 module VagrantPlugins
   module Cloudstack
     module Action

--- a/lib/vagrant-cloudstack/plugin.rb
+++ b/lib/vagrant-cloudstack/plugin.rb
@@ -24,7 +24,7 @@ module VagrantPlugins
         Config
       end
 
-      provider(:cloudstack, parallel: true) do # Setup logging and i18n
+      provider(:cloudstack, { parallel: true, box_optional:  true}) do # Setup logging and i18n
         setup_logging
         setup_i18n
 


### PR DESCRIPTION
I've adapted the existing rsync test and added a new one for the vm lifecycle (the simplest possible) that use the `config.vm.box` attribute to set the template.

To run the tests on a bash-like shell, some variables need to be exported:

``` bash
export CLOUDSTACK_HOST="..."
export CLOUDSTACK_API_KEY="..."
export CLOUDSTACK_SECRET_KEY="..."
export PUBLIC_SOURCE_NAT_IP="..."
export PUBLIC_SSH_PORT="2222"
export PRIVATE_SSH_PORT="22"
export PUBLIC_WINRM_PORT="6010"
export PRIVATE_WINRM_PORT="5985"
export ZONE_NAME="MCCP-ADMIN-1"
export NETWORK_NAME="..."
export SERVICE_OFFERING_NAME="..."
export LINUX_TEMPLATE_NAME="..."
export WINDOWS_TEMPLATE_NAME="..."
export OPEN_FIREWALL="false"
export SOURCE_CIDR="..."
export SSH_KEY="..."
export SSH_USER="..."
export WINDOWS_USER="Administrator"
```
